### PR TITLE
Double click to toggle fullscreen

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
 	"short_name": "__MSG_shrtExtName__",
 	"default_locale": "en",
 	"description": "__MSG_extDesc__",
-	"version": "3.3.1",
+	"version": "3.4",
 	
 	"icons": {
 		"16": "icon16.png",

--- a/page.js
+++ b/page.js
@@ -256,6 +256,16 @@ function handleClick(e){
 	return true; // Do not prevent default
 }
 
+function handleDblClick(e){
+	if(!dirVideo
+	&& !(e.target.classList
+	  && e.target.classList.contains(videoClass))){
+		return true; // Do not prevent default
+	}
+	shortcutFuncs.toggleFS(dirVideo || e.target);
+	return true; // Do not prevent default
+}
+
 function handleKeyDown(e){
 	if(!dirVideo
 	&& !(e.target.classList
@@ -421,6 +431,7 @@ function enableExtension(){
 	document.addEventListener("contextmenu", updateContextTarget);
 	
 	document.addEventListener("click", handleClick);
+	document.addEventListener("dblclick", handleDblClick);
 	document.addEventListener("keydown", handleKeyDown);
 	document.addEventListener("keypress", handleKeyOther);
 	document.addEventListener("keyup", handleKeyOther);
@@ -450,6 +461,7 @@ function disableExtension(){
 	document.removeEventListener("contextmenu", updateContextTarget);
 	
 	document.removeEventListener("click", handleClick);
+	document.removeEventListener("dblclick", handleDblClick);
 	document.removeEventListener("keydown", handleKeyDown);
 	document.removeEventListener("keypress", handleKeyOther);
 	document.removeEventListener("keyup", handleKeyOther);


### PR DESCRIPTION
This is a pretty common feature in flash-based video players, and YouTube does it too.

Double clicking does briefly pause (or play) the video. It doesn't bother me but if you like, I can add a short timeout to the click handler so this doesn't happen.