### PR TITLE
Options page tweaks

### DIFF
--- a/options.html
+++ b/options.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!DOCTYPE html>
 <html>
 <head>
 	<meta charset="UTF-8">

--- a/options.html
+++ b/options.html
@@ -20,7 +20,7 @@
 		.label, .input {
 			display: inline-block;
 			vertical-align: middle;
-			height: 1.5em;
+			min-height: 1.5em;
 		}
 		.label, .comment {
 			padding-right: 10px;


### PR DESCRIPTION
I guess my default sans-serif font is a little wider than yours, because my options page looked like this:
![options-before](https://cloud.githubusercontent.com/assets/11184137/21586218/50718c52-d09c-11e6-8e9b-b7585723b282.png)

The `div.label`s effectively had a maximum height, so the extra lines would overlap whatever's below them. Using `min-height` instead allows them to grow as necessary. Looks like this now:
![options-after](https://cloud.githubusercontent.com/assets/11184137/21586221/56857d2e-d09c-11e6-84c8-79b6a4823471.png)

