### PR TITLE
Increase options page width

### DIFF
--- a/options.html
+++ b/options.html
@@ -6,7 +6,7 @@
 	<style type="text/css">
 		body {
 			background-color: #FFF;
-			width: 100%;
+			width: 450px;
 			height: 100%;
 			box-sizing: border-box;
 			margin: 0;


### PR DESCRIPTION
Another issue with my slightly-wider font. Now inputs are wrapping to the next line:

![options](https://cloud.githubusercontent.com/assets/11184137/21953621/61f323f6-da0a-11e6-92e0-9011b86166c2.png)

Following the suggestion in Chrome's [options page docs](https://developer.chrome.com/extensions/optionsV2#sizing), I set an absolute width for the body. It's a little larger than the minimum size needed for everything to look right for me (430px minimum, I went with 450px).