### PR TITLE
Increase options page width

### DIFF
--- a/options.html
+++ b/options.html
@@ -19,6 +19,7 @@
 		}
 		.options {
 			overflow-y: auto;
+			width: 410px;
 			height: 300px;
 			resize: both;
 			background:


### PR DESCRIPTION
Another issue with my slightly-wider font. Now inputs are wrapping to the next line:

![options](https://cloud.githubusercontent.com/assets/11184137/21953621/61f323f6-da0a-11e6-92e0-9011b86166c2.png)

Following the suggestion in Chrome's [options page docs](https://developer.chrome.com/extensions/optionsV2#sizing), I set an absolute width for the `div.options` element. It's a little larger than the minimum size needed for everything to look right for me (401px minimum, I went with 410px).