### PR TITLE
Check click/dblclick event target for direct videos

### DIFF
--- a/page.js
+++ b/page.js
@@ -248,7 +248,7 @@ function ignoreAllIndirectVideos(){
 }
 
 function handleClick(e){
-	if(!dirVideo
+	if(!(dirVideo && e.target === dirVideo)
 	&& !(e.target.dataset
 	  && e.target.dataset[videoAttribute])){
 		return true; // Do not prevent default
@@ -275,9 +275,10 @@ function handleClick(e){
 }
 
 function handleDblClick(e){
-	if(!settings.dblFullScreen || (!dirVideo
-	&& !(e.target.dataset
-	  && e.target.dataset[videoAttribute]))){
+	if(!settings.dblFullScreen
+	|| (!(dirVideo && e.target === dirVideo)
+	  && !(e.target.dataset
+	    && e.target.dataset[videoAttribute]))){
 		return true; // Do not prevent default
 	}
 	const v = dirVideo || e.target;


### PR DESCRIPTION
Fixes #9 

I assumed that being able to click _outside_ the video to play/pause wasn't actually a feature.